### PR TITLE
Tune Kafka and add replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# ClickHouse - Kafka
+
+## Deploy
+
+Download and start all docker images.
+
+```
+$ docker-compose up
+```
+
+Connect to ClickHouse using https://tabix.io/:
+- Username: default
+- Host: https://localhost:8123
+- Name: <choose any>
+  
+Connect to Kafka using Web UI on http://localhost:8000;
+
+Finally, start a producer:
+
+```sh
+$ pip install -r requirements.txt
+$ python producer.py
+```
+
+## Roadmap
+
+### Initial implementation
+
+- Picture with a project architecture;
+
+- ~~Add ClickHouse to docker-compose~~;
+- ~~Add Kafka to docker-compose~~;
+- ~~Write a simple artificial producer~~;
+
+- <details><summary><strike>Sharding/Replication for Kafka</strike></summary>
+
+  Sharding is implemented by partitioning Kafka topics and is specified by `partitions` parameter. Replication is specified by `replication factor` - how many   replicas should be distributed across available nodes. 
+
+  Links:
+  - How replication works in Kafka: https://kafka.apache.org/documentation/#replication
+  </details>
+
+- Sharding/Replication for ClichHouse;
+- <details><summary><strike>Kafka: producer -> Kafka "exact-once" reliable delivery</strike></summary>
+
+  The reliability/durability is ensured by KafkaProducer `acks` parameter, which specify the number of required acknowledgemets from Kafka nodes. See: https://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html#kafka.KafkaProducer
+
+  > The number of acknowledgments the producer requires the leader to have received before considering a request complete. This controls the durability of records that are sent. ...
+
+  The "exact-once" delivery sematics supported by "idempotence" parameter, which force Kafka to make deduplication of messages. Links: 
+  - https://kafka.apache.org/documentation/#semantics (Since 0.11.0.0, the Kafka producer also supports an idempotent delivery option which guarantees that resending will not result in duplicate entries in the log);
+  - https://www.cloudkarafka.com/blog/2019-04-10-apache-kafka-idempotent-producer-avoiding-message-duplication.html
+
+  </details>
+
+- Kafka/ClickHouse: Kafka -> Consumer "exact-once" delivery or some deduplication mechanism (add a comment);
+- ClickHouse: research and prevent data losses;
+- Make a simple notes with a list of circumstances by which our system may fail;

--- a/clickhouse/tables.sql
+++ b/clickhouse/tables.sql
@@ -1,10 +1,10 @@
 CREATE database storage;
 
-CREATE TABLE storage.queue (
+CREATE TABLE IF NOT EXISTS storage.queue (
     id UInt32,
     timestamp UInt64,
     data Float64
-  ) ENGINE = Kafka('192.168.1.67:9092', 'test', 'group1')
+  ) ENGINE = Kafka('kafka-1:19093,kafka-2:19093', 'telemetry', 'telemetry-group')
               SETTINGS kafka_format = 'JSONEachRow',
                        kafka_num_consumers = 1;
 

--- a/create_topics.sh
+++ b/create_topics.sh
@@ -1,0 +1,6 @@
+docker run wurstmeister/kafka bash -c " 
+    kafka-topics.sh --create \
+        --zookeeper host.docker.internal:2181 \
+        --topic telemetry \
+        --partitions 2 \
+        --replication-factor 2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
   ch:
     image: yandex/clickhouse-server
     volumes:
+      - ./clickhouse/tables.sql:/docker-entrypoint-initdb.d/tables.sql
       - ./clickhouse/config:/etc/clickhouse-server
     ports:
       - "8123:8123"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,30 @@ services:
     depends_on:
       - zookeeper
 
+  kafka-rest-proxy:
+    image: confluentinc/cp-kafka-rest:5.5.1
+    hostname: kafka-rest-proxy
+    ports:
+      - "8082:8082"
+    environment:
+      KAFKA_REST_LISTENERS: http://0.0.0.0:8082/
+      KAFKA_REST_HOST_NAME: kafka-rest-proxy
+      KAFKA_REST_BOOTSTRAP_SERVERS: PLAINTEXT://kafka-1:19093,PLAINTEXT://kafka-2:29093
+    depends_on:
+      - kafka-1
+      - kafka-2
+
+  kafka-topics-ui:
+    image: landoop/kafka-topics-ui:0.9.4
+    hostname: kafka-topics-ui
+    ports:
+      - "8000:8000"
+    environment:
+      KAFKA_REST_PROXY_URL: "http://kafka-rest-proxy:8082/"
+      PROXY: "true"
+    depends_on:
+      - kafka-rest-proxy
+
   ch:
     image: yandex/clickhouse-server
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,35 @@ services:
     ports:
       - "2181:2181"
 
-  kafka:
+  kafka-1:
     image: wurstmeister/kafka
     ports:
-      - "9092:9092"
+      - "19092:19092"
+      - "19093:19093"
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: 192.168.1.67
+      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
+      KAFKA_ADVERTISED_LISTENERS: OUTSIDE://localhost:19092,INSIDE://:19093
+      KAFKA_LISTENERS: OUTSIDE://:19092,INSIDE://:19093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT 
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "test:1:1"
+    depends_on:
+      - zookeeper
+
+  kafka-2:
+    image: wurstmeister/kafka
+    ports:
+      - "29092:29092"
+      - "29093:29093"
+    environment:
+      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
+      KAFKA_ADVERTISED_LISTENERS: OUTSIDE://localhost:29092,INSIDE://:29093
+      KAFKA_LISTENERS: OUTSIDE://:29092,INSIDE://:29093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT 
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    depends_on:
+      - zookeeper
 
   ch:
     image: yandex/clickhouse-server
@@ -22,6 +43,5 @@ services:
     ports:
       - "8123:8123"
     depends_on:
-      - kafka
-    links:
-      - kafka
+      - kafka-1
+      - kafka-2

--- a/producer.py
+++ b/producer.py
@@ -3,9 +3,14 @@ from json import dumps
 from kafka import KafkaProducer
 import time
 import random
+import logging
 
-producer = KafkaProducer(bootstrap_servers='localhost:9092',
-                         value_serializer=lambda x: dumps(x).encode('utf-8'))
+
+producer = KafkaProducer(
+    bootstrap_servers='localhost:19092',
+    acks="all", # Receive acks from all the Kafka followers
+    value_serializer=lambda x: dumps(x).encode('utf-8')
+)
 
 for e in range(1000):
     timenow = int(time.time())
@@ -14,5 +19,6 @@ for e in range(1000):
         "timestamp": timenow,
         "data": e
     }
-    producer.send('test', value=data)
+    producer.send('telemetry', value=data)
+    print("data sent")
     sleep(1)

--- a/producer.py
+++ b/producer.py
@@ -1,16 +1,16 @@
 from time import sleep
 from json import dumps
-from kafka import KafkaProducer
+from confluent_kafka import Producer
 import time
 import random
 import logging
 
 
-producer = KafkaProducer(
-    bootstrap_servers='localhost:19092',
-    acks="all", # Receive acks from all the Kafka followers
-    value_serializer=lambda x: dumps(x).encode('utf-8')
-)
+producer = Producer({
+    "bootstrap.servers": "localhost:19092",
+    "enable.idempotence": True,
+    "request.required.acks": "all",
+})
 
 for e in range(1000):
     timenow = int(time.time())
@@ -19,6 +19,6 @@ for e in range(1000):
         "timestamp": timenow,
         "data": e
     }
-    producer.send('telemetry', value=data)
+    producer.produce(topic='telemetry', value=dumps(data))
     print("data sent")
     sleep(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+kafka-python==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-kafka-python==2.0.2
+confluent-kafka==1.5.0 


### PR DESCRIPTION
Changes:
- Replace kafka-python by confluent-kafka-python lib in order to support `idempotence` parameter;
- Add acks="all" param to make sure that the data sent always commited by all kafka followers;
- Make second node for kafka;
- Create tables for CH on startup;
- Add a Web UI for Kafka topics.
- Add Readme with simple roadmap;