### PR TITLE
Add metrics storage for clickhouse and kafka performance monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM wurstmeister/kafka
+
+ADD prom-jmx-agent-config.yml /usr/app/prom-jmx-agent-config.yml
+ADD https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.6/jmx_prometheus_javaagent-0.6.jar /usr/app/jmx_prometheus_javaagent.jar

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Connect to ClickHouse using https://tabix.io/:
   
 Connect to Kafka using Web UI on http://localhost:8000;
 
-Connect to Grafana on localhost:9090 as admin (pass: admin) and add Prometheus data source;
+Connect to Grafana on localhost:3000 as admin (pass: admin) and add Prometheus data source (http://prometheus:9090);
 
 Add kafka dashboard:
 Create -> import -> import via grafana.com -> enter dashboard id (721)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Connect to ClickHouse using https://tabix.io/:
   
 Connect to Kafka using Web UI on http://localhost:8000;
 
+Connect to Grafana on localhost:9090 as admin (pass: admin) and add Prometheus data source;
+
+Add kafka dashboard:
+Create -> import -> import via grafana.com -> enter dashboard id (721)
+
+
 Finally, start a producer:
 
 ```sh
@@ -58,9 +64,9 @@ $ python producer.py
 - Make a simple notes with a list of circumstances by which our system may fail;
 
 ### Performance testing
-- Add metrics storage (Prometheus or Graphite). Kafka and CH both should support it;
-- Connect ClickHouse with metrics storage;
-- Connect Kafka with metrics storage;
+- ~~Add metrics storage (Prometheus or Graphite). Kafka and CH both should support it~~;
+- ~~Connect ClickHouse with metrics storage~~;
+- ~~Connect Kafka with metrics storage~~;
 - Write a device test load using python + locust or python + multiprocessing or smth else;
 - Make stress test;
 - May be deploy all of it on the Google Cloud or AWS (with free subscription);

--- a/clickhouse/config/config.xml
+++ b/clickhouse/config/config.xml
@@ -312,17 +312,15 @@
         asynchronous_metrics - send data from table system.asynchronous_metrics
         status_info - send data from different component from CH, ex: Dictionaries status
     -->
-    <!--
     <prometheus>
         <endpoint>/metrics</endpoint>
-        <port>9363</port>
+        <port>8001</port>
 
         <metrics>true</metrics>
         <events>true</events>
         <asynchronous_metrics>true</asynchronous_metrics>
         <status_info>true</status_info>
     </prometheus>
-    -->
 
     <!-- Query log. Used only for queries with setting log_queries = 1. -->
     <query_log>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,3 +74,21 @@ services:
     depends_on:
       - kafka-1
       - kafka-2
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/config/prometheus.yml:/etc/prometheus/prometheus.yml
+    depends_on:
+      - ch
+      - kafka-1
+      - kafka-2
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+#    volumes:
+#      - ./grafana:/var/lib/grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
       - "2181:2181"
 
   kafka-1:
-    image: wurstmeister/kafka
+    build: .
+#    image: wurstmeister/kafka
     ports:
       - "19092:19092"
       - "19093:19093"
@@ -18,11 +19,13 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT 
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OPTS: -javaagent:/usr/app/jmx_prometheus_javaagent.jar=7071:/usr/app/prom-jmx-agent-config.yml
     depends_on:
       - zookeeper
 
   kafka-2:
-    image: wurstmeister/kafka
+    build: .
+#    image: wurstmeister/kafka
     ports:
       - "29092:29092"
       - "29093:29093"
@@ -33,6 +36,7 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT 
       KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_OPTS: -javaagent:/usr/app/jmx_prometheus_javaagent.jar=7071:/usr/app/prom-jmx-agent-config.yml
     depends_on:
       - zookeeper
 

--- a/prom-jmx-agent-config.yml
+++ b/prom-jmx-agent-config.yml
@@ -1,0 +1,88 @@
+lowercaseOutputName: true
+rules:
+  - pattern : kafka.cluster<type=(.+), name=(.+), topic=(.+), partition=(.+)><>Value
+    name: kafka_cluster_$1_$2
+    labels:
+      topic: "$3"
+      partition: "$4"
+  - pattern : kafka.log<type=Log, name=(.+), topic=(.+), partition=(.+)><>Value
+    name: kafka_log_$1
+    labels:
+      topic: "$2"
+      partition: "$3"
+  - pattern : kafka.controller<type=(.+), name=(.+)><>(Count|Value)
+    name: kafka_controller_$1_$2
+  - pattern : kafka.network<type=(.+), name=(.+)><>Value
+    name: kafka_network_$1_$2
+  - pattern : kafka.network<type=(.+), name=(.+)PerSec, request=(.+)><>Count
+    name: kafka_network_$1_$2_total
+    labels:
+      request: "$3"
+  - pattern : kafka.network<type=(.+), name=(\w+), networkProcessor=(.+)><>Count
+    name: kafka_network_$1_$2
+    labels:
+      request: "$3"
+    type: COUNTER
+  - pattern : kafka.network<type=(.+), name=(\w+), request=(\w+)><>Count
+    name: kafka_network_$1_$2
+    labels:
+      request: "$3"
+  - pattern : kafka.network<type=(.+), name=(\w+)><>Count
+    name: kafka_network_$1_$2
+  - pattern : kafka.server<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count
+    name: kafka_server_$1_$2_total
+    labels:
+      topic: "$3"
+  - pattern : kafka.server<type=(.+), name=(.+)PerSec\w*><>Count
+    name: kafka_server_$1_$2_total
+    type: COUNTER
+
+  - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>(Count|Value)
+    name: kafka_server_$1_$2
+    labels:
+      clientId: "$3"
+      topic: "$4"
+      partition: "$5"
+  - pattern : kafka.server<type=(.+), name=(.+), topic=(.+), partition=(.*)><>(Count|Value)
+    name: kafka_server_$1_$2
+    labels:
+      topic: "$3"
+      partition: "$4"
+  - pattern : kafka.server<type=(.+), name=(.+), topic=(.+)><>(Count|Value)
+    name: kafka_server_$1_$2
+    labels:
+      topic: "$3"
+    type: COUNTER
+
+  - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>(Count|Value)
+    name: kafka_server_$1_$2
+    labels:
+      clientId: "$3"
+      broker: "$4:$5"
+  - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+)><>(Count|Value)
+    name: kafka_server_$1_$2
+    labels:
+      clientId: "$3"
+  - pattern : kafka.server<type=(.+), name=(.+)><>(Count|Value)
+    name: kafka_server_$1_$2
+
+  - pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
+    name: kafka_$1_$2_$3_total
+  - pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count
+    name: kafka_$1_$2_$3_total
+    labels:
+      topic: "$4"
+    type: COUNTER
+  - pattern : kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, topic=(.+), partition=(.+)><>Count
+    name: kafka_$1_$2_$3_total
+    labels:
+      topic: "$4"
+      partition: "$5"
+    type: COUNTER
+  - pattern : kafka.(\w+)<type=(.+), name=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3_$4
+    type: COUNTER
+  - pattern : kafka.(\w+)<type=(.+), name=(.+), (\w+)=(.+)><>(Count|Value)
+    name: kafka_$1_$2_$3_$6
+    labels:
+      "$4": "$5"

--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: [ 'localhost:9090' ]
+
+  - job_name: clickhouse
+    static_configs:
+      - targets: [ 'ch:8001' ]
+
+  - job_name: kafka
+    static_configs:
+      - targets: [ 'kafka-1:7071', 'kafka-2:7071' ]
+    tls_config:
+      insecure_skip_verify: true


### PR DESCRIPTION
Dashboard for kafka works out of the box: [kafka dashboard link](https://grafana.com/grafana/dashboards/721).
Existing dashboards for clickhouse don't work, but all the required metrics can be found in prometheus.
Use `docker-compose up --build -d` to run the containers.